### PR TITLE
don't require an api url (was defaulting to localhost instead of api.cloud.llamaindex.ai)

### DIFF
--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -19,12 +19,11 @@ export-types = "{{project_name_snake}}.export_types:export_types"
 [dependency-groups]
 dev = [
     "ruff>=0.11.10",
-    "llama_deploy",
     "typescript>=0.0.12",
     "ty>=0.0.1a16",
     "pytest>=8.4.1",
     "hatch>=1.14.1",
-    "llamactl>=0.3.0a3"
+    "llamactl==0.3.0a4"
 ]
 
 [build-system]

--- a/test-proj/pyproject.toml
+++ b/test-proj/pyproject.toml
@@ -19,12 +19,11 @@ export-types = "test_proj.export_types:export_types"
 [dependency-groups]
 dev = [
     "ruff>=0.11.10",
-    "llama_deploy",
     "typescript>=0.0.12",
     "ty>=0.0.1a16",
     "pytest>=8.4.1",
     "hatch>=1.14.1",
-    "llamactl>=0.3.0a3"
+    "llamactl==0.3.0a4"
 ]
 
 [build-system]

--- a/test-proj/ui/src/lib/client.ts
+++ b/test-proj/ui/src/lib/client.ts
@@ -15,7 +15,7 @@ const projectId = import.meta.env.VITE_LLAMA_DEPLOY_PROJECT_ID;
 
 // Configure the platform client
 cloudApiClient.setConfig({
-  baseUrl: apiBaseUrl,
+  ...(apiBaseUrl && { baseUrl: apiBaseUrl }),
   headers: {
     // optionally use a backend API token scoped to a project. For local development,
     ...(platformToken && { authorization: `Bearer ${platformToken}` }),

--- a/ui/src/lib/client.ts
+++ b/ui/src/lib/client.ts
@@ -15,7 +15,7 @@ const projectId = import.meta.env.VITE_LLAMA_DEPLOY_PROJECT_ID;
 
 // Configure the platform client
 cloudApiClient.setConfig({
-  baseUrl: apiBaseUrl,
+  ...(apiBaseUrl && { baseUrl: apiBaseUrl }),
   headers: {
     // optionally use a backend API token scoped to a project. For local development,
     ...(platformToken && { authorization: `Bearer ${platformToken}` }),


### PR DESCRIPTION
and avoid the broken versions of llamactl (0.3.0a5/a6)