### PR TITLE
prevent workflows 2

### DIFF
--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -6,11 +6,12 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "llama-cloud-services>=0.6.57",
-    "llama-index-workflows>=1.1.0",
+    "llama-index-workflows>=1.3.0",
     "python-dotenv>=1.1.0",
     "jsonref>=1.1.0",
     "click>=8.2.1",
     "httpx>=0.28.1",
+    "llama-index-core>=0.13.0"
 ]
 
 [project.scripts]

--- a/test-proj/pyproject.toml
+++ b/test-proj/pyproject.toml
@@ -6,11 +6,12 @@ readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "llama-cloud-services>=0.6.57",
-    "llama-index-workflows>=1.1.0",
+    "llama-index-workflows>=1.3.0",
     "python-dotenv>=1.1.0",
     "jsonref>=1.1.0",
     "click>=8.2.1",
     "httpx>=0.28.1",
+    "llama-index-core>=0.13.0"
 ]
 
 [project.scripts]


### PR DESCRIPTION
it crashes when llama-index-core < 0.13, which pulls in llama-index-workflows>=2, and promptly imports things that don't exist