### PR TITLE
Revert "Rename deployment url id to deployment name"

### DIFF
--- a/test-proj/ui/vite.config.ts
+++ b/test-proj/ui/vite.config.ts
@@ -4,7 +4,7 @@ import path from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig(({}) => {
-  const deploymentName = process.env.LLAMA_DEPLOY_DEPLOYMENT_NAME;
+  const deploymentId = process.env.LLAMA_DEPLOY_DEPLOYMENT_URL_ID;
   const basePath = process.env.LLAMA_DEPLOY_DEPLOYMENT_BASE_PATH;
   const projectId = process.env.LLAMA_DEPLOY_PROJECT_ID;
   const port = process.env.PORT ? Number(process.env.PORT) : 3000;
@@ -26,10 +26,8 @@ export default defineConfig(({}) => {
     },
     base: basePath,
     define: {
-      // Primary define uses NAME
-      "import.meta.env.VITE_LLAMA_DEPLOY_DEPLOYMENT_NAME": JSON.stringify(
-        deploymentName
-      ),
+      "import.meta.env.VITE_LLAMA_DEPLOY_DEPLOYMENT_NAME":
+        JSON.stringify(deploymentId),
       "import.meta.env.VITE_LLAMA_DEPLOY_DEPLOYMENT_BASE_PATH": JSON.stringify(basePath),
       ...(projectId && {
         "import.meta.env.VITE_LLAMA_DEPLOY_PROJECT_ID":

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -4,7 +4,7 @@ import path from "path";
 
 // https://vitejs.dev/config/
 export default defineConfig(({}) => {
-  const deploymentName = process.env.LLAMA_DEPLOY_DEPLOYMENT_NAME;
+  const deploymentId = process.env.LLAMA_DEPLOY_DEPLOYMENT_URL_ID;
   const basePath = process.env.LLAMA_DEPLOY_DEPLOYMENT_BASE_PATH;
   const projectId = process.env.LLAMA_DEPLOY_PROJECT_ID;
   const port = process.env.PORT ? Number(process.env.PORT) : 3000;
@@ -26,10 +26,8 @@ export default defineConfig(({}) => {
     },
     base: basePath,
     define: {
-      // Primary define uses NAME
-      "import.meta.env.VITE_LLAMA_DEPLOY_DEPLOYMENT_NAME": JSON.stringify(
-        deploymentName
-      ),
+      "import.meta.env.VITE_LLAMA_DEPLOY_DEPLOYMENT_NAME":
+        JSON.stringify(deploymentId),
       "import.meta.env.VITE_LLAMA_DEPLOY_DEPLOYMENT_BASE_PATH": JSON.stringify(basePath),
       ...(projectId && {
         "import.meta.env.VITE_LLAMA_DEPLOY_PROJECT_ID":


### PR DESCRIPTION
Reverts run-llama/template-workflow-data-extraction#38

Unfortunately, there's a reason for this discrepancy--its currently intentional to not set the deployment name, so that the UI can use the _public agent when running locally. This breaks that behavior.

Reverting before rethinking a better solution