### PR TITLE
Fix issues with ts build breaking client

### DIFF
--- a/test-proj/ui/package.json
+++ b/test-proj/ui/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@babel/runtime": "^7.27.6",
     "@lezer/highlight": "^1.2.1",
-    "@llamaindex/ui": "^2.1.1",
+    "@llamaindex/ui": "^2.1.2",
     "@radix-ui/themes": "^3.2.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/test-proj/ui/src/pages/HomePage.tsx
+++ b/test-proj/ui/src/pages/HomePage.tsx
@@ -8,7 +8,6 @@ import {
 import type { TypedAgentData } from "llama-cloud-services/beta/agent";
 import styles from "./HomePage.module.css";
 import { useNavigate } from "react-router-dom";
-import { agentClient } from "@/lib/client";
 import { useEffect, useState } from "react";
 
 export default function HomePage() {
@@ -45,20 +44,18 @@ function TaskList() {
     <div className={styles.page}>
       <main className={styles.main}>
         <div className={styles.grid}>
-          <ItemCount title="Total Items" client={agentClient} />
+          <ItemCount title="Total Items" />
           <ItemCount
             title="Reviewed"
             filter={{
               status: { eq: "approved" },
             }}
-            client={agentClient}
           />
           <ItemCount
             title="Needs Review"
             filter={{
               status: { eq: "pending_review" },
             }}
-            client={agentClient}
           />
         </div>
         <div className={styles.commandBar}>

--- a/test-proj/ui/src/pages/ItemPage.tsx
+++ b/test-proj/ui/src/pages/ItemPage.tsx
@@ -13,7 +13,6 @@ import MyJsonSchema from "../schemas/MySchema.json" with { type: "json" };
 import { useToolbar } from "@/lib/ToolbarContext";
 import { useNavigate } from "react-router-dom";
 import { modifyJsonSchema } from "@llamaindex/ui/lib";
-import { agentClient } from "@/lib/client";
 import { APP_TITLE } from "@/lib/config";
 
 export default function ItemPage() {
@@ -27,7 +26,6 @@ export default function ItemPage() {
     jsonSchema: modifyJsonSchema(MyJsonSchema as any, {}),
     itemId: itemId as string,
     isMock: false,
-    client: agentClient,
   });
 
   const navigate = useNavigate();

--- a/ui/package.json.jinja
+++ b/ui/package.json.jinja
@@ -16,7 +16,7 @@
   "dependencies": {
     "@babel/runtime": "^7.27.6",
     "@lezer/highlight": "^1.2.1",
-    "@llamaindex/ui": "^2.1.1",
+    "@llamaindex/ui": "^2.1.2",
     "@radix-ui/themes": "^3.2.1",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/ui/src/pages/HomePage.tsx
+++ b/ui/src/pages/HomePage.tsx
@@ -8,7 +8,6 @@ import {
 import type { TypedAgentData } from "llama-cloud-services/beta/agent";
 import styles from "./HomePage.module.css";
 import { useNavigate } from "react-router-dom";
-import { agentClient } from "@/lib/client";
 import { useEffect, useState } from "react";
 
 export default function HomePage() {
@@ -45,20 +44,18 @@ function TaskList() {
     <div className={styles.page}>
       <main className={styles.main}>
         <div className={styles.grid}>
-          <ItemCount title="Total Items" client={agentClient} />
+          <ItemCount title="Total Items" />
           <ItemCount
             title="Reviewed"
             filter={{
               status: { eq: "approved" },
             }}
-            client={agentClient}
           />
           <ItemCount
             title="Needs Review"
             filter={{
               status: { eq: "pending_review" },
             }}
-            client={agentClient}
           />
         </div>
         <div className={styles.commandBar}>

--- a/ui/src/pages/ItemPage.tsx
+++ b/ui/src/pages/ItemPage.tsx
@@ -13,7 +13,6 @@ import MyJsonSchema from "../schemas/MySchema.json" with { type: "json" };
 import { useToolbar } from "@/lib/ToolbarContext";
 import { useNavigate } from "react-router-dom";
 import { modifyJsonSchema } from "@llamaindex/ui/lib";
-import { agentClient } from "@/lib/client";
 import { APP_TITLE } from "@/lib/config";
 
 export default function ItemPage() {
@@ -27,7 +26,6 @@ export default function ItemPage() {
     jsonSchema: modifyJsonSchema(MyJsonSchema as any, {}),
     itemId: itemId as string,
     isMock: false,
-    client: agentClient,
   });
 
   const navigate = useNavigate();


### PR DESCRIPTION
WorkflowClient is no longer a param for some extraction components. Not sure how this snuck past previous builds, I think this was updated since @llamaindex/2.1.2?